### PR TITLE
Add spring-hadoop link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated list of awesome HBase projects and resources.
 * [Apex](https://github.com/apache/apex-malhar/tree/master/contrib/src/main/java/com/datatorrent/contrib/hbase) - Apex-HBase connector.
 * [Flink](https://github.com/apache/flink/tree/master/flink-connectors/flink-hbase) - Flink-HBase connector.
 * [Spark](https://github.com/hortonworks-spark/shc) - Spark-HBase connector.
+* [Spring for Apache Hadoop](https://projects.spring.io/spring-hadoop/) - Spring-Hadoop integration, including HBase support.
 
 ### Tools
 


### PR DESCRIPTION
Spring supports Hadoop including HBase, called `spring-hadoop`. 😄 
I think this could a useful reference as well!

https://projects.spring.io/spring-hadoop/
> DAO support (Template & Callbacks) for HBase.